### PR TITLE
Use `Unsafe.SizeOf` instead of `Marshal.SizeOf`.

### DIFF
--- a/src/DotNetIsolator/ShadowStack.cs
+++ b/src/DotNetIsolator/ShadowStack.cs
@@ -1,4 +1,5 @@
-﻿using System.Runtime.InteropServices;
+﻿using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 using Wasmtime;
 
 namespace DotNetIsolator;
@@ -26,11 +27,11 @@ internal class ShadowStack : IDisposable
         _stackPtr = _stackBasePtr;
     }
 
-    public ShadowStackEntry<T> Push<T>() where T: struct
+    public ShadowStackEntry<T> Push<T>() where T: unmanaged
     {
         var ptr = _stackPtr;
 
-        var len = Marshal.SizeOf<T>();
+        var len = Unsafe.SizeOf<T>();
         _stackPtr += len;
 
         var valueBytes = _memory.GetSpan(ptr, len);
@@ -39,9 +40,9 @@ internal class ShadowStack : IDisposable
         return new ShadowStackEntry<T>(this, ref value, ptr);
     }
 
-    public void Pop<T>(int expectedAddress) where T : struct
+    public void Pop<T>(int expectedAddress) where T : unmanaged
     {
-        var len = Marshal.SizeOf<T>();
+        var len = Unsafe.SizeOf<T>();
         _stackPtr -= len;
 
         if (_stackPtr != expectedAddress)

--- a/src/DotNetIsolator/ShadowStackEntry.cs
+++ b/src/DotNetIsolator/ShadowStackEntry.cs
@@ -1,6 +1,6 @@
 ﻿namespace DotNetIsolator;
 
-internal readonly ref struct ShadowStackEntry<T> where T: struct
+internal readonly ref struct ShadowStackEntry<T> where T: unmanaged
 {
     public readonly ref T Value;
     public readonly int Address;


### PR DESCRIPTION
The latter returns the size of a value when marshalled through P/Invoke; we need the size of the value in managed memory which the former provides. These two sizes might be different in cases such as `bool` or `char`.

The `ShadowStack` generic methods were also constrained to unmanaged types.