### PR TITLE
QoL Updates

### DIFF
--- a/src/DotNetIsolator.WasmApp/Helpers.cs
+++ b/src/DotNetIsolator.WasmApp/Helpers.cs
@@ -31,9 +31,9 @@ public static class Helpers
         return MessagePackSerializer.Serialize(value, ContractlessStandardResolverAllowPrivate.Options);
     }
 
-    public static void GetMemberHandle(MemberInfo member, ref MemberTypes memberType, ref IntPtr handle)
+    public static void GetMemberHandle(object member, ref MemberTypes memberType, ref IntPtr handle)
     {
-        memberType = member.MemberType;
+        memberType = (member as MemberInfo)?.MemberType ?? 0;
         switch (member)
         {
             case Type type:
@@ -44,6 +44,9 @@ public static class Helpers
                 break;
             case FieldInfo field:
                 handle = field.FieldHandle.Value;
+                break;
+            default:
+                handle = IntPtr.Zero;
                 break;
         }
     }

--- a/src/DotNetIsolator.WasmApp/Helpers.cs
+++ b/src/DotNetIsolator.WasmApp/Helpers.cs
@@ -3,7 +3,7 @@ using MessagePack.Resolvers;
 
 namespace DotNetIsolator.WasmApp;
 
-public static class Serialization
+public static class Helpers
 {
     public static unsafe object? Deserialize<T>(byte* value, int valueLength)
     {

--- a/src/DotNetIsolator.WasmApp/Helpers.cs
+++ b/src/DotNetIsolator.WasmApp/Helpers.cs
@@ -1,5 +1,6 @@
 ﻿using MessagePack;
 using MessagePack.Resolvers;
+using System.Reflection;
 
 namespace DotNetIsolator.WasmApp;
 
@@ -28,5 +29,22 @@ public static class Helpers
         // TODO: Should we really be pinning the result value here, or is it safe to return
         // a MonoObject* to unmanaged code and then use mono_gchandle_new(..., true) from there?
         return MessagePackSerializer.Serialize(value, ContractlessStandardResolverAllowPrivate.Options);
+    }
+
+    public static void GetMemberHandle(MemberInfo member, ref MemberTypes memberType, ref IntPtr handle)
+    {
+        memberType = member.MemberType;
+        switch (member)
+        {
+            case Type type:
+                handle = type.TypeHandle.Value;
+                break;
+            case MethodBase method:
+                handle = method.MethodHandle.Value;
+                break;
+            case FieldInfo field:
+                handle = field.FieldHandle.Value;
+                break;
+        }
     }
 }

--- a/src/DotNetIsolator.WasmApp/Helpers.cs
+++ b/src/DotNetIsolator.WasmApp/Helpers.cs
@@ -18,7 +18,12 @@ public static class Helpers
 
     internal static unsafe object? Deserialize<T>(Memory<byte> value)
     {
-        var result = MessagePackSerializer.Deserialize<T>(value, MessagePackSerializer.Typeless.DefaultOptions);
+        var result = MessagePackSerializer.Typeless.Deserialize(value, TypelessContractlessStandardResolver.Options);
+
+        if(result != null && result is not T)
+        {
+            throw new ArgumentException($"Could not deserialize as {typeof(T)}, got {result.GetType()} instead.", nameof(value));
+        }
 
         // Console.WriteLine($"Deserialized value of type {result?.GetType().FullName} with value {result}");
         return result;

--- a/src/DotNetIsolator.WasmApp/Program.cs
+++ b/src/DotNetIsolator.WasmApp/Program.cs
@@ -8,5 +8,5 @@ AppContext.SetSwitch("System.Globalization.Invariant", true);
 // For preinit, warm up the serialization code paths
 var captured = new { prop1 = new List<string> { "a", "b" } };
 var lambda = (string a, bool b) => { Console.WriteLine(a + b + captured.prop1.Count + System.Runtime.InteropServices.RuntimeInformation.OSArchitecture); };
-var serialized2 = DotNetIsolator.WasmApp.Serialization.Serialize(lambda.Target!);
-var deserialized2 = DotNetIsolator.WasmApp.Serialization.Deserialize<object>(serialized2);
+var serialized2 = DotNetIsolator.WasmApp.Helpers.Serialize(lambda.Target!);
+var deserialized2 = DotNetIsolator.WasmApp.Helpers.Deserialize<object>(serialized2);

--- a/src/DotNetIsolator.WasmApp/Program.cs
+++ b/src/DotNetIsolator.WasmApp/Program.cs
@@ -9,4 +9,4 @@ AppContext.SetSwitch("System.Globalization.Invariant", true);
 var captured = new { prop1 = new List<string> { "a", "b" } };
 var lambda = (string a, bool b) => { Console.WriteLine(a + b + captured.prop1.Count + System.Runtime.InteropServices.RuntimeInformation.OSArchitecture); };
 var serialized2 = DotNetIsolator.WasmApp.Serialization.Serialize(lambda.Target!);
-var deserialized2 = DotNetIsolator.WasmApp.Serialization.Deserialize(serialized2);
+var deserialized2 = DotNetIsolator.WasmApp.Serialization.Deserialize<object>(serialized2);

--- a/src/DotNetIsolator.WasmApp/Serialization.cs
+++ b/src/DotNetIsolator.WasmApp/Serialization.cs
@@ -5,21 +5,19 @@ namespace DotNetIsolator.WasmApp;
 
 public static class Serialization
 {
-    public static unsafe object? Deserialize(byte* value, int valueLength)
+    public static unsafe object? Deserialize<T>(byte* value, int valueLength)
     {
         // Instead of using ToArray (or UnmanagedMemoryStream) you could have a pool of byte[]
         // buffers on the guest side and have the host serialize directly into their memory, then
         // there would be no allocations on either side, and this code could work with a Memory<byte>
         // for whatever region within one of those buffers.
         var memoryCopy = new Span<byte>(value, valueLength).ToArray();
-        return Deserialize(memoryCopy);
+        return Deserialize<T>(memoryCopy);
     }
 
-    internal static unsafe object? Deserialize(Memory<byte> value)
+    internal static unsafe object? Deserialize<T>(Memory<byte> value)
     {
-        // TODO: Instead of using Typeless, consider making this a generic method and having the
-        // C code produce the closed type based on the declared parameter types of the method
-        var result = MessagePackSerializer.Typeless.Deserialize(value);
+        var result = MessagePackSerializer.Deserialize<T>(value, MessagePackSerializer.Typeless.DefaultOptions);
 
         // Console.WriteLine($"Deserialized value of type {result?.GetType().FullName} with value {result}");
         return result;

--- a/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
+++ b/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
@@ -18,6 +18,11 @@ typedef struct RunnerInvocation {
 #define RESULT_TYPE_SERIALIZE 0
 #define RESULT_TYPE_HANDLE 1
 
+__attribute__((export_name("dotnetisolator_realloc")))
+void* dotnetisolator_realloc(void *ptr, size_t size) {
+	return realloc(ptr, size);
+}
+
 __attribute__((export_name("dotnetisolator_instantiate_class")))
 MonoGCHandle dotnetisolator_instantiate_class(MonoClass* class) {
 	MonoObject* instance = mono_object_new(NULL, class);

--- a/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
+++ b/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
@@ -3,6 +3,7 @@
 #include <mono/metadata/appdomain.h>
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/class.h>
+#include <mono/metadata/reflection.h>
 #include <mono-wasi/driver.h>
 
 typedef struct RunnerInvocation {
@@ -250,4 +251,18 @@ MonoGCHandle dotnetisolator_deserialize_object(void* length_prefixed_buffer, Mon
 		*class = mono_object_get_class(mono_gchandle_get_target((uint32_t)result));
 		return result;
 	}
+}
+
+__attribute__((export_name("dotnetisolator_reflect_class")))
+MonoGCHandle dotnetisolator_reflect_class(MonoClass* class, MonoClass** result_class) {
+	MonoObject* result = (MonoObject*)mono_type_get_object(mono_get_root_domain(), mono_class_get_type(class));
+	*result_class = mono_object_get_class(result);
+	return (MonoGCHandle)mono_gchandle_new(result, /* pinned */ 0);
+}
+
+__attribute__((export_name("dotnetisolator_reflect_method")))
+MonoGCHandle dotnetisolator_reflect_method(MonoMethod* method, MonoClass** result_class) {
+	MonoObject* result = (MonoObject*)mono_method_get_object(mono_get_root_domain(), method, mono_method_get_class(method));
+	*result_class = mono_object_get_class(result);
+	return (MonoGCHandle)mono_gchandle_new(result, /* pinned */ 0);
 }

--- a/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
+++ b/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
@@ -159,7 +159,12 @@ void dotnetisolator_invoke_method(RunnerInvocation* invocation) {
 		//printf("GCHandle: %p, Method: %p, Arg0: %p\n", invocation->target, invocation->method_ptr, invocation->arg0);
 		MonoObject* target = invocation->target ? mono_gchandle_get_target((uint32_t)(invocation->target)) : 0;
 
-		MonoObject* result = mono_wasm_invoke_method(invocation->method_ptr, target, method_params, &exc);
+		MonoObject* result;
+		if (invocation->method_ptr) {
+			result = mono_wasm_invoke_method(invocation->method_ptr, target, method_params, &exc);
+		} else {
+			result = target;
+		}
 
 		for (int i = 0; i < num_args; i++) {
 			if (arg_handles[i]) {

--- a/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
+++ b/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
@@ -22,6 +22,8 @@ typedef struct RunnerInvocation {
 #define RESULT_TYPE_SERIALIZE 0
 #define RESULT_TYPE_HANDLE 1
 
+#define HELPERS_CLASS "DotNetIsolator.WasmApp","DotNetIsolator.WasmApp","Helpers"
+
 __attribute__((export_name("dotnetisolator_realloc")))
 void* dotnetisolator_realloc(void *ptr, size_t size) {
 	return realloc(ptr, size);
@@ -115,7 +117,7 @@ void* deserialize_param(void* length_prefixed_buffer, MonoType* param_type, Mono
 
 	if (*(int*)length_prefixed_buffer) {
 		if (deserialize_param_dotnet_method == 0) {
-			deserialize_param_dotnet_method = lookup_dotnet_method("DotNetIsolator.WasmApp", "DotNetIsolator.WasmApp", "Serialization", "Deserialize", 2);
+			deserialize_param_dotnet_method = lookup_dotnet_method(HELPERS_CLASS, "Deserialize", 2);
 		}
 
 		if (!param_type) {
@@ -179,7 +181,7 @@ void serialize_return_value(MonoObject* value, RunnerInvocation* invocation, Mon
 	}
 
 	if (serialize_return_value_dotnet_method == 0) {
-		serialize_return_value_dotnet_method = lookup_dotnet_method("DotNetIsolator.WasmApp", "DotNetIsolator.WasmApp", "Serialization", "Serialize", -1);
+		serialize_return_value_dotnet_method = lookup_dotnet_method(HELPERS_CLASS, "Serialize", -1);
 	}
 
 	void* method_params[] = { value };

--- a/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
+++ b/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
@@ -296,3 +296,14 @@ MonoGCHandle dotnetisolator_reflect_method(MonoMethod* method, MonoClass** resul
 	*result_class = mono_object_get_class(result);
 	return (MonoGCHandle)mono_gchandle_new(result, /* pinned */ 0);
 }
+
+__attribute__((export_name("dotnetisolator_get_object_class")))
+MonoClass* dotnetisolator_get_object_class() {
+	return mono_get_object_class();
+}
+
+__attribute__((export_name("dotnetisolator_get_object_hash")))
+int dotnetisolator_get_object_hash(MonoGCHandle gcHandle) {
+	MonoObject* obj = mono_gchandle_get_target((uint32_t)gcHandle);
+	return mono_object_hash(obj);
+}

--- a/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
+++ b/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
@@ -197,6 +197,13 @@ void serialize_return_value(MonoObject* value, RunnerInvocation* invocation, Mon
 	invocation->result_handle = (MonoGCHandle)mono_gchandle_new(byte_array, /* pinned */ 1);
 }
 
+MonoString* empty_string_on_null(MonoString* str) {
+	if (!str) {
+		return mono_string_empty(mono_get_root_domain());
+	}
+	return str;
+}
+
 __attribute__((export_name("dotnetisolator_invoke_method")))
 void dotnetisolator_invoke_method(RunnerInvocation* invocation) {
 	MonoObject* exc = NULL;
@@ -262,7 +269,7 @@ void dotnetisolator_invoke_method(RunnerInvocation* invocation) {
 	if (exc) {
 		// Return a string representation of the error
 		invocation->result_type = RESULT_TYPE_HANDLE;
-		invocation->result_exception = exc_msg;
+		invocation->result_exception = empty_string_on_null(exc_msg);
 		serialize_return_value(exc, invocation, &exc, &exc_msg);
 	}
 }

--- a/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
+++ b/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
@@ -307,3 +307,35 @@ int dotnetisolator_get_object_hash(MonoGCHandle gcHandle) {
 	MonoObject* obj = mono_gchandle_get_target((uint32_t)gcHandle);
 	return mono_object_hash(obj);
 }
+
+__attribute__((export_name("dotnetisolator_make_generic_class")))
+MonoClass* dotnetisolator_make_generic_type(MonoClass* class, int num_classes, void** classes) {
+	for (int i = 0; i < num_classes; i++) {
+		classes[i] = mono_class_get_type((MonoClass*)classes[i]);
+	}
+	MonoGenericInst* inst = mono_metadata_get_generic_inst(num_classes, (MonoType**)classes);
+	free(classes);
+	MonoGenericInst* context[2] = {
+		inst,
+		NULL
+	};
+	MonoType* result = mono_class_inflate_generic_type(mono_class_get_type(class), (MonoGenericContext*)context);
+	if (!result) {
+		return NULL;
+	}
+	return mono_class_from_mono_type(result);
+}
+
+__attribute__((export_name("dotnetisolator_make_generic_method")))
+MonoMethod* dotnetisolator_make_generic_method(MonoMethod* method, int num_classes, void** classes) {
+	for (int i = 0; i < num_classes; i++) {
+		classes[i] = mono_class_get_type((MonoClass*)classes[i]);
+	}
+	MonoGenericInst* inst = mono_metadata_get_generic_inst(num_classes, (MonoType**)classes);
+	free(classes);
+	MonoGenericInst* context[2] = {
+		NULL,
+		inst
+	};
+	return mono_class_inflate_generic_method(method, (MonoGenericContext*)context);
+}

--- a/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
+++ b/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
@@ -34,8 +34,8 @@ void dotnetisolator_release_object(MonoGCHandle gcHandle) {
 	}
 }
 
-__attribute__((export_name("dotnetisolator_get_class")))
-MonoClass* dotnetisolator_get_class(MonoGCHandle gcHandle) {
+__attribute__((export_name("dotnetisolator_get_object_class")))
+MonoClass* dotnetisolator_get_object_class(MonoGCHandle gcHandle) {
 	if (gcHandle) {
 		MonoObject* object = mono_gchandle_get_target((uint32_t)(gcHandle));
 		if (object) {
@@ -46,20 +46,14 @@ MonoClass* dotnetisolator_get_class(MonoGCHandle gcHandle) {
 }
 
 __attribute__((export_name("dotnetisolator_lookup_class")))
-MonoClass* dotnetisolator_lookup_class(char* assembly_name, char* namespace, char* type_name, char** error_msg) {
+MonoClass* dotnetisolator_lookup_class(char* assembly_name, char* namespace, char* type_name) {
 	//printf("Trying to find %s %s %s\n", assembly_name, namespace, type_name);
+
 	MonoClass* result = NULL;
-	*error_msg = NULL;
-	char* namespace_or_fallback = namespace ? namespace : "(no namespace)";
 
 	MonoAssembly* assembly = mono_wasm_assembly_load(assembly_name);
-	if (!assembly) {
-		asprintf(error_msg, "Could not find class [%s]%s.%s because the assembly %s could not be found.", assembly_name, namespace_or_fallback, type_name, assembly_name);
-	} else {
+	if (assembly) {
 		result = mono_wasm_assembly_find_class(assembly, namespace, type_name);
-		if (!result) {
-			asprintf(error_msg, "Could not find class [%s]%s.%s because the type %s could not be found in the assembly.", assembly_name, namespace_or_fallback, type_name, type_name);
-		}
 	}
 
 	free(assembly_name);
@@ -69,14 +63,10 @@ MonoClass* dotnetisolator_lookup_class(char* assembly_name, char* namespace, cha
 }
 
 __attribute__((export_name("dotnetisolator_lookup_method")))
-MonoMethod* dotnetisolator_lookup_method(MonoClass* class, char* method_name, int num_params, char** error_msg) {
+MonoMethod* dotnetisolator_lookup_method(MonoClass* class, char* method_name, int num_params) {
 	//printf("Trying to find %s %i\n", method_name, num_params);
-	*error_msg = NULL;
 
 	MonoMethod* result = mono_wasm_assembly_find_method(class, method_name, num_params);
-	if (!result) {
-		asprintf(error_msg, "Could not find method %s in the type with the correct number of parameters.", method_name);
-	}
 
 	free(method_name);
 	return result;

--- a/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
+++ b/src/DotNetIsolator.WasmApp/native/dotnetisolate.c
@@ -161,6 +161,12 @@ void dotnetisolator_invoke_method(RunnerInvocation* invocation) {
 
 		MonoObject* result;
 		if (invocation->method_ptr) {
+			if (target) {
+				MonoMethod* method = mono_object_get_virtual_method(target, invocation->method_ptr);
+				if (method) {
+					invocation->method_ptr = method;
+				}
+			}
 			result = mono_wasm_invoke_method(invocation->method_ptr, target, method_params, &exc);
 		} else {
 			result = target;

--- a/src/DotNetIsolator/DotNetIsolator.csproj
+++ b/src/DotNetIsolator/DotNetIsolator.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net7.0</TargetFramework>
+		<TargetFramework>netstandard2.1</TargetFramework>
+		<LangVersion>10.0</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<WasmAppProjectName>DotNetIsolator.WasmApp</WasmAppProjectName>
@@ -28,8 +29,9 @@
 	<ItemGroup>		
 		<ProjectReference Include="..\DotNetIsolator.WasmApp\DotNetIsolator.WasmApp.csproj">
 		  <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
+		  <SkipGetTargetFrameworkProperties>true</SkipGetTargetFrameworkProperties>
 		</ProjectReference>
-		<Content Include="..\$(WasmAppProjectName)\bin\$(Configuration)\$(TargetFramework)\$(WasmAppProjectName).wasm">
+		<Content Include="..\$(WasmAppProjectName)\bin\$(Configuration)\net7.0\$(WasmAppProjectName).wasm">
 			<Visible>false</Visible>
 			<Link>$(BundledFilesDir)%(Filename)%(Extension)</Link>
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>

--- a/src/DotNetIsolator/DotNetIsolator.csproj
+++ b/src/DotNetIsolator/DotNetIsolator.csproj
@@ -1,10 +1,11 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>netstandard2.1</TargetFramework>
+		<TargetFramework>netstandard2.0</TargetFramework>
 		<LangVersion>10.0</LangVersion>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
+		<AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 		<WasmAppProjectName>DotNetIsolator.WasmApp</WasmAppProjectName>
 		<BundledFilesDir>IsolatedRuntimeHost\</BundledFilesDir>
 		<BundledWasmAssembliesDir>$(BundledFilesDir)WasmAssemblies\</BundledWasmAssembliesDir>
@@ -13,7 +14,9 @@
 
 	<ItemGroup>
 		<PackageReference Include="MessagePack" Version="2.5.103" />
-		<PackageReference Include="Wasmtime" Version="5.0.0" />
+		<PackageReference Include="Wasmtime" Version="9.0.3" />
+		<PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
+		<PackageReference Include="System.Memory" Version="4.5.5" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/DotNetIsolator/IIsolatedGCHandle.cs
+++ b/src/DotNetIsolator/IIsolatedGCHandle.cs
@@ -1,0 +1,6 @@
+﻿namespace DotNetIsolator;
+
+internal interface IIsolatedGCHandle
+{
+    int? GetGCHandle(IsolatedRuntime runtime);
+}

--- a/src/DotNetIsolator/IsolatedAllocator.cs
+++ b/src/DotNetIsolator/IsolatedAllocator.cs
@@ -9,10 +9,8 @@ public sealed class IsolatedAllocator : MemoryManager<byte>, IBufferWriter<byte>
     const int minSize = 4;
 
     int _memoryPtr;
-    int _offset;
+    int _offset = sizeof(int);
     int _allocatedSize;
-
-    public int WrittenBytes => _offset;
 
     public IsolatedAllocator(IsolatedRuntime runtimeInstance)
     {
@@ -23,8 +21,16 @@ public sealed class IsolatedAllocator : MemoryManager<byte>, IBufferWriter<byte>
     {
         int ptr = _memoryPtr;
 
+        if (ptr == 0)
+        {
+            // allocate empty buffer to hold the length
+            ptr = _runtimeInstance.Alloc(sizeof(int));
+        }
+
+        _runtimeInstance.WriteInt32(ptr, _offset - sizeof(int));
+
         _memoryPtr = 0;
-        _offset = 0;
+        _offset = sizeof(int);
         _allocatedSize = 0;
 
         return ptr;

--- a/src/DotNetIsolator/IsolatedAllocator.cs
+++ b/src/DotNetIsolator/IsolatedAllocator.cs
@@ -1,0 +1,74 @@
+﻿using System.Buffers;
+
+namespace DotNetIsolator;
+
+public sealed class IsolatedAllocator : IBufferWriter<byte>, IDisposable
+{
+    readonly IsolatedRuntime _runtimeInstance;
+
+    const int minSize = 4;
+
+    int _memoryPtr;
+    int _offset;
+    int _allocatedSize;
+
+    public IsolatedAllocator(IsolatedRuntime runtimeInstance)
+    {
+        _runtimeInstance = runtimeInstance;
+
+        _memoryPtr = runtimeInstance.Alloc(minSize);
+        _allocatedSize = minSize;
+    }
+
+    public int Release()
+    {
+        int ptr = _memoryPtr;
+
+        _memoryPtr = _runtimeInstance.Alloc(minSize);
+        _offset = 0;
+        _allocatedSize = minSize;
+
+        return ptr;
+    }
+
+    private void Reserve(int size)
+    {
+        if (size > _allocatedSize)
+        {
+            _memoryPtr = _runtimeInstance.Realloc(_memoryPtr, _allocatedSize * 2);
+            _allocatedSize *= 2;
+        }
+    }
+
+    public void Advance(int count)
+    {
+        Reserve(Math.Max(_allocatedSize, _offset + count + minSize));
+        _offset += count;
+    }
+
+    public Span<byte> GetSpan(int sizeHint = 0)
+    {
+        Reserve(_offset + Math.Max(minSize, sizeHint));
+        return _runtimeInstance.GetMemory(_memoryPtr + _offset, _allocatedSize - _offset);
+    }
+
+    public Memory<byte> GetMemory(int sizeHint = 0)
+    {
+        throw new NotImplementedException();
+    }
+
+    public void Dispose()
+    {
+        if (_memoryPtr != 0)
+        {
+            _runtimeInstance.Free(_memoryPtr);
+            _memoryPtr = 0;
+        }
+        GC.SuppressFinalize(this);
+    }
+
+    ~IsolatedAllocator()
+    {
+        Dispose();
+    }
+}

--- a/src/DotNetIsolator/IsolatedClass.cs
+++ b/src/DotNetIsolator/IsolatedClass.cs
@@ -1,6 +1,6 @@
 ﻿namespace DotNetIsolator;
 
-public class IsolatedClass : IEquatable<IsolatedClass>
+public class IsolatedClass : IsolatedMember, IEquatable<IsolatedClass>
 {
     private readonly IsolatedRuntime _runtimeInstance;
     private readonly int _monoClassPtr;
@@ -36,5 +36,10 @@ public class IsolatedClass : IEquatable<IsolatedClass>
     public IsolatedMethod? GetMethod(string methodName, int numArgs = -1)
     {
         return _runtimeInstance.GetMethod(_monoClassPtr, methodName, numArgs);
+    }
+
+    protected override IsolatedObject GetReflectionObject()
+    {
+        return _runtimeInstance.GetReflectionClass(_monoClassPtr);
     }
 }

--- a/src/DotNetIsolator/IsolatedClass.cs
+++ b/src/DotNetIsolator/IsolatedClass.cs
@@ -38,6 +38,11 @@ public class IsolatedClass : IsolatedMember, IEquatable<IsolatedClass>
         return _runtimeInstance.GetMethod(_monoClassPtr, methodName, numArgs);
     }
 
+    public IsolatedMethod? GetMethod(string methodDesc, bool matchNamespace)
+    {
+        return _runtimeInstance.GetMethod(_monoClassPtr, methodDesc, matchNamespace);
+    }
+
     protected override IsolatedObject GetReflectionObject()
     {
         return _runtimeInstance.GetReflectionClass(_monoClassPtr);

--- a/src/DotNetIsolator/IsolatedClass.cs
+++ b/src/DotNetIsolator/IsolatedClass.cs
@@ -2,66 +2,57 @@
 
 public class IsolatedClass : IsolatedMember, IEquatable<IsolatedClass>
 {
-    internal readonly int _monoClassPtr;
-
-    internal IsolatedClass(IsolatedRuntime runtimeInstance, int monoClassPtr) : base(runtimeInstance)
+    internal IsolatedClass(IsolatedRuntime runtimeInstance, int monoClassPtr) : base(runtimeInstance, monoClassPtr)
     {
-        _monoClassPtr = monoClassPtr;
+
     }
 
     public bool Equals(IsolatedClass other)
     {
-        return
-            _runtimeInstance == other._runtimeInstance &&
-            _monoClassPtr == other._monoClassPtr;
+        return base.Equals(other);
     }
 
-    public override bool Equals(object obj)
+    public override bool Equals(IsolatedMember other)
     {
-        return obj is IsolatedClass cls && Equals(cls);
-    }
-
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(_runtimeInstance, _monoClassPtr);
+        return other is IsolatedClass && base.Equals(other);
     }
 
     public IsolatedObject CreateInstance()
     {
-        return _runtimeInstance.CreateObject(_monoClassPtr);
+        return Runtime.CreateObject(_monoPtr);
     }
 
     public IsolatedMethod? GetMethod(string methodName, int numArgs = -1)
     {
-        return _runtimeInstance.GetMethod(_monoClassPtr, methodName, numArgs);
+        return Runtime.GetMethod(_monoPtr, methodName, numArgs);
     }
 
     public IsolatedMethod? GetMethod(string methodDesc, bool matchNamespace)
     {
-        return _runtimeInstance.GetMethod(_monoClassPtr, methodDesc, matchNamespace);
+        return Runtime.GetMethod(_monoPtr, methodDesc, matchNamespace);
     }
 
     public IsolatedClass? MakeGenericClass(params IsolatedClass[] genericArguments)
     {
         if (genericArguments.Length == 0)
         {
-            return _runtimeInstance.MakeGenericClass(_monoClassPtr, Array.Empty<int>());
+            return Runtime.MakeGenericClass(_monoPtr, Array.Empty<int>());
         }
         Span<int> argsPtr = stackalloc int[genericArguments.Length];
         for (int i = 0; i < genericArguments.Length; i++)
         {
             var arg = genericArguments[i];
-            if (arg._runtimeInstance != _runtimeInstance)
+            if (arg.Runtime != Runtime)
             {
                 throw new ArgumentException("Generic arguments must all come from the same runtime.", nameof(genericArguments));
             }
-            argsPtr[i] = arg._monoClassPtr;
+            argsPtr[i] = arg._monoPtr;
         }
-        return _runtimeInstance.MakeGenericClass(_monoClassPtr, argsPtr);
+        return Runtime.MakeGenericClass(_monoPtr, argsPtr);
     }
 
     protected override IsolatedObject GetReflectionObject()
     {
-        return _runtimeInstance.GetReflectionClass(_monoClassPtr);
+        return Runtime.GetReflectionClass(_monoPtr);
     }
 }

--- a/src/DotNetIsolator/IsolatedClass.cs
+++ b/src/DotNetIsolator/IsolatedClass.cs
@@ -1,0 +1,23 @@
+﻿namespace DotNetIsolator;
+
+public class IsolatedClass
+{
+    private readonly IsolatedRuntime _runtimeInstance;
+    private readonly int _monoClassPtr;
+
+    internal IsolatedClass(IsolatedRuntime runtimeInstance, int monoClassPtr)
+    {
+        _runtimeInstance = runtimeInstance;
+        _monoClassPtr = monoClassPtr;
+    }
+
+    public IsolatedObject CreateInstance()
+    {
+        return _runtimeInstance.CreateObject(_monoClassPtr);
+    }
+
+    public IsolatedMethod GetMethod(string methodName, int numArgs = -1)
+    {
+        return _runtimeInstance.GetMethod(_monoClassPtr, methodName, numArgs);
+    }
+}

--- a/src/DotNetIsolator/IsolatedClass.cs
+++ b/src/DotNetIsolator/IsolatedClass.cs
@@ -16,7 +16,7 @@ public class IsolatedClass
         return _runtimeInstance.CreateObject(_monoClassPtr);
     }
 
-    public IsolatedMethod GetMethod(string methodName, int numArgs = -1)
+    public IsolatedMethod? GetMethod(string methodName, int numArgs = -1)
     {
         return _runtimeInstance.GetMethod(_monoClassPtr, methodName, numArgs);
     }

--- a/src/DotNetIsolator/IsolatedClass.cs
+++ b/src/DotNetIsolator/IsolatedClass.cs
@@ -1,6 +1,6 @@
 ﻿namespace DotNetIsolator;
 
-public class IsolatedClass
+public class IsolatedClass : IEquatable<IsolatedClass>
 {
     private readonly IsolatedRuntime _runtimeInstance;
     private readonly int _monoClassPtr;
@@ -9,6 +9,23 @@ public class IsolatedClass
     {
         _runtimeInstance = runtimeInstance;
         _monoClassPtr = monoClassPtr;
+    }
+
+    public bool Equals(IsolatedClass other)
+    {
+        return
+            _runtimeInstance == other._runtimeInstance &&
+            _monoClassPtr == other._monoClassPtr;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return obj is IsolatedClass cls && Equals(cls);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(_runtimeInstance, _monoClassPtr);
     }
 
     public IsolatedObject CreateInstance()

--- a/src/DotNetIsolator/IsolatedException.cs
+++ b/src/DotNetIsolator/IsolatedException.cs
@@ -9,6 +9,11 @@ public class IsolatedException : Exception
 
     }
 
+    public IsolatedException(string? message) : base(message)
+    {
+
+    }
+
     public IsolatedException(string? message, IsolatedObject innerExceptionObject) : base(message, DeserializeException(innerExceptionObject))
     {
         InnerExceptionObject = innerExceptionObject;

--- a/src/DotNetIsolator/IsolatedException.cs
+++ b/src/DotNetIsolator/IsolatedException.cs
@@ -2,7 +2,27 @@
 
 public class IsolatedException : Exception
 {
-    public IsolatedException(string? message) : base(message)
+    public IsolatedObject? InnerExceptionObject { get; }
+
+    internal IsolatedException()
     {
+
+    }
+
+    public IsolatedException(string? message, IsolatedObject innerExceptionObject) : base(message, DeserializeException(innerExceptionObject))
+    {
+        InnerExceptionObject = innerExceptionObject;
+    }
+
+    static Exception DeserializeException(IsolatedObject innerExceptionObject)
+    {
+        try
+        {
+            return innerExceptionObject.Deserialize<Exception>();
+        }
+        catch (Exception e)
+        {
+            return e;
+        }
     }
 }

--- a/src/DotNetIsolator/IsolatedMember.cs
+++ b/src/DotNetIsolator/IsolatedMember.cs
@@ -13,6 +13,10 @@ public abstract class IsolatedMember : IDisposable, IIsolatedGCHandle
         return ReflectionObject.ToString();
     }
 
+    public abstract override bool Equals(object obj);
+
+    public abstract override int GetHashCode();
+
     protected virtual void Dispose(bool disposing)
     {
         if (disposing)

--- a/src/DotNetIsolator/IsolatedMember.cs
+++ b/src/DotNetIsolator/IsolatedMember.cs
@@ -1,27 +1,46 @@
 ﻿namespace DotNetIsolator;
 
-public abstract class IsolatedMember : IDisposable, IIsolatedGCHandle
+public abstract class IsolatedMember : IDisposable, IEquatable<IsolatedMember>, IIsolatedGCHandle
 {
-    protected internal readonly IsolatedRuntime _runtimeInstance;
+    public IsolatedRuntime Runtime { get; }
+
+    internal readonly int _monoPtr;
+
+    public nint Handle => _monoPtr;
+
     IsolatedObject? reflectionObject;
 
     public IsolatedObject ReflectionObject => reflectionObject ??= GetReflectionObject();
 
-    public IsolatedMember(IsolatedRuntime runtimeInstance)
+    public IsolatedMember(IsolatedRuntime runtimeInstance, int monoPtr)
     {
-        _runtimeInstance = runtimeInstance;
+        Runtime = runtimeInstance;
+        _monoPtr = monoPtr;
     }
 
     protected abstract IsolatedObject GetReflectionObject();
+
+    public virtual bool Equals(IsolatedMember other)
+    {
+        return
+            Runtime == other.Runtime &&
+            Handle == other.Handle;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return obj is IsolatedMember method && Equals(method);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(Runtime, Handle);
+    }
 
     public override string ToString()
     {
         return ReflectionObject.ToString();
     }
-
-    public abstract override bool Equals(object obj);
-
-    public abstract override int GetHashCode();
 
     protected virtual void Dispose(bool disposing)
     {

--- a/src/DotNetIsolator/IsolatedMember.cs
+++ b/src/DotNetIsolator/IsolatedMember.cs
@@ -18,6 +18,11 @@ public abstract class IsolatedMember : IDisposable, IEquatable<IsolatedMember>, 
         _monoPtr = monoPtr;
     }
 
+    public static explicit operator IsolatedObject(IsolatedMember member)
+    {
+        return member.GetReflectionObject();
+    }
+
     protected abstract IsolatedObject GetReflectionObject();
 
     public virtual bool Equals(IsolatedMember other)

--- a/src/DotNetIsolator/IsolatedMember.cs
+++ b/src/DotNetIsolator/IsolatedMember.cs
@@ -2,9 +2,15 @@
 
 public abstract class IsolatedMember : IDisposable, IIsolatedGCHandle
 {
+    protected internal readonly IsolatedRuntime _runtimeInstance;
     IsolatedObject? reflectionObject;
 
     public IsolatedObject ReflectionObject => reflectionObject ??= GetReflectionObject();
+
+    public IsolatedMember(IsolatedRuntime runtimeInstance)
+    {
+        _runtimeInstance = runtimeInstance;
+    }
 
     protected abstract IsolatedObject GetReflectionObject();
 

--- a/src/DotNetIsolator/IsolatedMember.cs
+++ b/src/DotNetIsolator/IsolatedMember.cs
@@ -1,0 +1,38 @@
+﻿namespace DotNetIsolator;
+
+public abstract class IsolatedMember : IDisposable, IIsolatedGCHandle
+{
+    IsolatedObject? reflectionObject;
+
+    public IsolatedObject ReflectionObject => reflectionObject ??= GetReflectionObject();
+
+    protected abstract IsolatedObject GetReflectionObject();
+
+    public override string ToString()
+    {
+        return ReflectionObject.ToString();
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            if (reflectionObject != null)
+            {
+                reflectionObject.Dispose();
+                reflectionObject = null;
+            }
+        }
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    int? IIsolatedGCHandle.GetGCHandle(IsolatedRuntime runtime)
+    {
+        return ReflectionObject.GetGCHandle(runtime);
+    }
+}

--- a/src/DotNetIsolator/IsolatedMethod.cs
+++ b/src/DotNetIsolator/IsolatedMethod.cs
@@ -14,7 +14,7 @@ public class IsolatedMethod
     }
 
     public TRes Invoke<TRes>(IsolatedObject? instance)
-        => _runtimeInstance.InvokeDotNetMethod<TRes>(_monoMethodPtr, instance, Span<int>.Empty);
+        => _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, Span<int>.Empty);
 
     public TRes Invoke<T0, TRes>(IsolatedObject? instance, T0 param0)
     {
@@ -28,7 +28,7 @@ public class IsolatedMethod
 
         try
         {
-            return _runtimeInstance.InvokeDotNetMethod<TRes>(_monoMethodPtr, instance, argAddresses);
+            return _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, argAddresses);
         }
         finally
         {
@@ -46,7 +46,7 @@ public class IsolatedMethod
 
         try
         {
-            return _runtimeInstance.InvokeDotNetMethod<TRes>(_monoMethodPtr, instance, argAddresses);
+            return _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, argAddresses);
         }
         finally
         {
@@ -67,7 +67,7 @@ public class IsolatedMethod
 
         try
         {
-            return _runtimeInstance.InvokeDotNetMethod<TRes>(_monoMethodPtr, instance, argAddresses);
+            return _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, argAddresses);
         }
         finally
         {
@@ -91,7 +91,7 @@ public class IsolatedMethod
 
         try
         {
-            return _runtimeInstance.InvokeDotNetMethod<TRes>(_monoMethodPtr, instance, argAddresses);
+            return _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, argAddresses);
         }
         finally
         {
@@ -118,7 +118,7 @@ public class IsolatedMethod
 
         try
         {
-            return _runtimeInstance.InvokeDotNetMethod<TRes>(_monoMethodPtr, instance, argAddresses);
+            return _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, argAddresses);
         }
         finally
         {
@@ -145,7 +145,7 @@ public class IsolatedMethod
         }
         try
         {
-            return _runtimeInstance.InvokeDotNetMethod<TRes>(_monoMethodPtr, instance, argAddresses);
+            return _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, argAddresses);
         }
         finally
         {

--- a/src/DotNetIsolator/IsolatedMethod.cs
+++ b/src/DotNetIsolator/IsolatedMethod.cs
@@ -35,8 +35,9 @@ public class IsolatedMethod : IEquatable<IsolatedMethod>
     {
         // We might also want to special-case some basic known parameter types and skip MessagePack
         // for them, instead using ShadowStack and the raw bytes
+        _runtimeInstance.InitLengthPrefixedAllocator(allocator);
         MessagePackSerializer.Typeless.Serialize(allocator, value);
-        return allocator.Release();
+        return _runtimeInstance.ReleaseLengthPrefixedAllocator(allocator);
     }
 
     private TRes Invoke<TRes>(IsolatedObject? instance, Span<int> argAddresses)

--- a/src/DotNetIsolator/IsolatedMethod.cs
+++ b/src/DotNetIsolator/IsolatedMethod.cs
@@ -7,11 +7,8 @@ public class IsolatedMethod
     private readonly IsolatedRuntime _runtimeInstance;
     private readonly int _monoMethodPtr;
 
-    public string Name { get; }
-
-    internal IsolatedMethod(IsolatedRuntime runtimeInstance, string name, int monoMethodPtr)
+    internal IsolatedMethod(IsolatedRuntime runtimeInstance, int monoMethodPtr)
     {
-        Name = name;
         _runtimeInstance = runtimeInstance;
         _monoMethodPtr = monoMethodPtr;
     }

--- a/src/DotNetIsolator/IsolatedMethod.cs
+++ b/src/DotNetIsolator/IsolatedMethod.cs
@@ -35,9 +35,8 @@ public class IsolatedMethod : IEquatable<IsolatedMethod>
     {
         // We might also want to special-case some basic known parameter types and skip MessagePack
         // for them, instead using ShadowStack and the raw bytes
-        _runtimeInstance.InitLengthPrefixedAllocator(allocator);
         MessagePackSerializer.Typeless.Serialize(allocator, value);
-        return _runtimeInstance.ReleaseLengthPrefixedAllocator(allocator);
+        return allocator.Release();
     }
 
     private TRes Invoke<TRes>(IsolatedObject? instance, Span<int> argAddresses)

--- a/src/DotNetIsolator/IsolatedMethod.cs
+++ b/src/DotNetIsolator/IsolatedMethod.cs
@@ -2,7 +2,7 @@
 
 namespace DotNetIsolator;
 
-public class IsolatedMethod
+public class IsolatedMethod : IEquatable<IsolatedMethod>
 {
     private readonly IsolatedRuntime _runtimeInstance;
     private readonly int _monoMethodPtr;
@@ -11,6 +11,23 @@ public class IsolatedMethod
     {
         _runtimeInstance = runtimeInstance;
         _monoMethodPtr = monoMethodPtr;
+    }
+
+    public bool Equals(IsolatedMethod other)
+    {
+        return
+            _runtimeInstance == other._runtimeInstance &&
+            _monoMethodPtr == other._monoMethodPtr;
+    }
+
+    public override bool Equals(object obj)
+    {
+        return obj is IsolatedMethod method && Equals(method);
+    }
+
+    public override int GetHashCode()
+    {
+        return HashCode.Combine(_runtimeInstance, _monoMethodPtr);
     }
 
     public TRes Invoke<TRes>(IsolatedObject? instance)

--- a/src/DotNetIsolator/IsolatedMethod.cs
+++ b/src/DotNetIsolator/IsolatedMethod.cs
@@ -30,18 +30,23 @@ public class IsolatedMethod : IEquatable<IsolatedMethod>
         return HashCode.Combine(_runtimeInstance, _monoMethodPtr);
     }
 
-    public TRes Invoke<TRes>(IsolatedObject? instance)
-        => _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, Span<int>.Empty);
-
-    public TRes Invoke<T0, TRes>(IsolatedObject? instance, T0 param0)
+    private int Serialize<T>(T value)
     {
         // Ideally we'd serialize directly into guest memory but that probably involves implementing
         // an IBufferWriter<byte> that knows how to allocate chunks of guest memory
         // We might also want to special-case some basic known parameter types and skip MessagePack
         // for them, instead using ShadowStack and the raw bytes
+        return _runtimeInstance.CopyValueLengthPrefixed(
+            MessagePackSerializer.Typeless.Serialize(value));
+    }
+
+    public TRes Invoke<TRes>(IsolatedObject? instance)
+        => _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, Span<int>.Empty);
+
+    public TRes Invoke<T0, TRes>(IsolatedObject? instance, T0 param0)
+    {
         Span<int> argAddresses = stackalloc int[1];
-        argAddresses[0] = _runtimeInstance.CopyValueLengthPrefixed(
-            MessagePackSerializer.Typeless.Serialize(param0));
+        argAddresses[0] = Serialize(param0);
 
         try
         {
@@ -56,10 +61,8 @@ public class IsolatedMethod : IEquatable<IsolatedMethod>
     public TRes Invoke<T0, T1, TRes>(IsolatedObject? instance, T0 param0, T1 param1)
     {
         Span<int> argAddresses = stackalloc int[2];
-        argAddresses[0] = _runtimeInstance.CopyValueLengthPrefixed(
-            MessagePackSerializer.Typeless.Serialize(param0));
-        argAddresses[1] = _runtimeInstance.CopyValueLengthPrefixed(
-            MessagePackSerializer.Typeless.Serialize(param1));
+        argAddresses[0] = Serialize(param0);
+        argAddresses[1] = Serialize(param1);
 
         try
         {
@@ -75,12 +78,9 @@ public class IsolatedMethod : IEquatable<IsolatedMethod>
     public TRes Invoke<T0, T1, T2, TRes>(IsolatedObject? instance, T0 param0, T1 param1, T2 param2)
     {
         Span<int> argAddresses = stackalloc int[3];
-        argAddresses[0] = _runtimeInstance.CopyValueLengthPrefixed(
-            MessagePackSerializer.Typeless.Serialize(param0));
-        argAddresses[1] = _runtimeInstance.CopyValueLengthPrefixed(
-            MessagePackSerializer.Typeless.Serialize(param1));
-        argAddresses[2] = _runtimeInstance.CopyValueLengthPrefixed(
-            MessagePackSerializer.Typeless.Serialize(param2));
+        argAddresses[0] = Serialize(param0);
+        argAddresses[1] = Serialize(param1);
+        argAddresses[2] = Serialize(param2);
 
         try
         {
@@ -97,14 +97,10 @@ public class IsolatedMethod : IEquatable<IsolatedMethod>
     public TRes Invoke<T0, T1, T2, T3, TRes>(IsolatedObject? instance, T0 param0, T1 param1, T2 param2, T3 param3)
     {
         Span<int> argAddresses = stackalloc int[4];
-        argAddresses[0] = _runtimeInstance.CopyValueLengthPrefixed(
-            MessagePackSerializer.Typeless.Serialize(param0));
-        argAddresses[1] = _runtimeInstance.CopyValueLengthPrefixed(
-            MessagePackSerializer.Typeless.Serialize(param1));
-        argAddresses[2] = _runtimeInstance.CopyValueLengthPrefixed(
-            MessagePackSerializer.Typeless.Serialize(param2));
-        argAddresses[3] = _runtimeInstance.CopyValueLengthPrefixed(
-            MessagePackSerializer.Typeless.Serialize(param3));
+        argAddresses[0] = Serialize(param0);
+        argAddresses[1] = Serialize(param1);
+        argAddresses[2] = Serialize(param2);
+        argAddresses[3] = Serialize(param3);
 
         try
         {
@@ -122,16 +118,11 @@ public class IsolatedMethod : IEquatable<IsolatedMethod>
     public TRes Invoke<T0, T1, T2, T3, T4, TRes>(IsolatedObject? instance, T0 param0, T1 param1, T2 param2, T3 param3, T4 param4)
     {
         Span<int> argAddresses = stackalloc int[5];
-        argAddresses[0] = _runtimeInstance.CopyValueLengthPrefixed(
-            MessagePackSerializer.Typeless.Serialize(param0));
-        argAddresses[1] = _runtimeInstance.CopyValueLengthPrefixed(
-            MessagePackSerializer.Typeless.Serialize(param1));
-        argAddresses[2] = _runtimeInstance.CopyValueLengthPrefixed(
-            MessagePackSerializer.Typeless.Serialize(param2));
-        argAddresses[3] = _runtimeInstance.CopyValueLengthPrefixed(
-            MessagePackSerializer.Typeless.Serialize(param3));
-        argAddresses[4] = _runtimeInstance.CopyValueLengthPrefixed(
-            MessagePackSerializer.Typeless.Serialize(param4));
+        argAddresses[0] = Serialize(param0);
+        argAddresses[1] = Serialize(param1);
+        argAddresses[2] = Serialize(param2);
+        argAddresses[3] = Serialize(param3);
+        argAddresses[4] = Serialize(param4);
 
         try
         {
@@ -157,8 +148,7 @@ public class IsolatedMethod : IEquatable<IsolatedMethod>
         Span<int> argAddresses = stackalloc int[args.Length];
         for (int i = 0; i < args.Length; i++)
         {
-            argAddresses[i] = _runtimeInstance.CopyValueLengthPrefixed(
-                MessagePackSerializer.Typeless.Serialize(args[i]));
+            argAddresses[i] = Serialize(args[i]);
         }
         try
         {

--- a/src/DotNetIsolator/IsolatedMethod.cs
+++ b/src/DotNetIsolator/IsolatedMethod.cs
@@ -33,6 +33,14 @@ public class IsolatedMethod : IEquatable<IsolatedMethod>
 
     private int Serialize<T>(T value, IsolatedAllocator allocator)
     {
+        if (value is IIsolatedGCHandle handle && handle.GetGCHandle(_runtimeInstance) is int gcHandle)
+        {
+            // Special size 0 case just with handle
+            var memory = _runtimeInstance.Alloc(2 * sizeof(int));
+            _runtimeInstance.WriteInt32(memory, 0);
+            _runtimeInstance.WriteInt32(memory + sizeof(int), gcHandle);
+            return memory;
+        }
         // We might also want to special-case some basic known parameter types and skip MessagePack
         // for them, instead using ShadowStack and the raw bytes
         MessagePackSerializer.Typeless.Serialize(allocator, value);

--- a/src/DotNetIsolator/IsolatedMethod.cs
+++ b/src/DotNetIsolator/IsolatedMethod.cs
@@ -39,13 +39,13 @@ public class IsolatedMethod : IEquatable<IsolatedMethod>
         return allocator.Release();
     }
 
-    public TRes Invoke<TRes>(IsolatedObject? instance)
-        => _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, Span<int>.Empty);
-
-    public TRes Invoke<T0, TRes>(IsolatedObject? instance, T0 param0)
+    private TRes Invoke<TRes>(IsolatedObject? instance, Span<int> argAddresses)
     {
-        Span<int> argAddresses = stackalloc int[1];
-        using var allocator = _runtimeInstance.GetAllocator();
+        return _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, argAddresses);
+    }
+
+    private TRes Invoke<T0, TRes>(IsolatedObject? instance, T0 param0, Span<int> argAddresses, IsolatedAllocator allocator)
+    {
         argAddresses[0] = Serialize(param0, allocator);
 
         try
@@ -56,90 +56,102 @@ public class IsolatedMethod : IEquatable<IsolatedMethod>
         {
             _runtimeInstance.Free(argAddresses[0]);
         }
+    }
+
+    private TRes Invoke<T0, T1, TRes>(IsolatedObject? instance, T0 param0, T1 param1, Span<int> argAddresses, IsolatedAllocator allocator)
+    {
+        argAddresses[1] = Serialize(param1, allocator);
+
+        try
+        {
+            return Invoke<T0, TRes>(instance, param0, argAddresses, allocator);
+        }
+        finally
+        {
+            _runtimeInstance.Free(argAddresses[1]);
+        }
+    }
+
+    private TRes Invoke<T0, T1, T2, TRes>(IsolatedObject? instance, T0 param0, T1 param1, T2 param2, Span<int> argAddresses, IsolatedAllocator allocator)
+    {
+        argAddresses[2] = Serialize(param2, allocator);
+
+        try
+        {
+            return Invoke<T0, T1, TRes>(instance, param0, param1, argAddresses, allocator);
+        }
+        finally
+        {
+            _runtimeInstance.Free(argAddresses[2]);
+        }
+    }
+
+    private TRes Invoke<T0, T1, T2, T3, TRes>(IsolatedObject? instance, T0 param0, T1 param1, T2 param2, T3 param3, Span<int> argAddresses, IsolatedAllocator allocator)
+    {
+        argAddresses[3] = Serialize(param3, allocator);
+
+        try
+        {
+            return Invoke<T0, T1, T2, TRes>(instance, param0, param1, param2, argAddresses, allocator);
+        }
+        finally
+        {
+            _runtimeInstance.Free(argAddresses[3]);
+        }
+    }
+
+    private TRes Invoke<T0, T1, T2, T3, T4, TRes>(IsolatedObject? instance, T0 param0, T1 param1, T2 param2, T3 param3, T4 param4, Span<int> argAddresses, IsolatedAllocator allocator)
+    {
+        argAddresses[4] = Serialize(param4, allocator);
+
+        try
+        {
+            return Invoke<T0, T1, T2, T3, TRes>(instance, param0, param1, param2, param3, argAddresses, allocator);
+        }
+        finally
+        {
+            _runtimeInstance.Free(argAddresses[4]);
+        }
+    }
+
+    public TRes Invoke<TRes>(IsolatedObject? instance)
+    {
+        return _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, ReadOnlySpan<int>.Empty);
+    }
+
+    public TRes Invoke<T0, TRes>(IsolatedObject? instance, T0 param0)
+    {
+        Span<int> argAddresses = stackalloc int[1];
+        using var allocator = _runtimeInstance.GetAllocator();
+        return Invoke<T0, TRes>(instance, param0, argAddresses, allocator);
     }
 
     public TRes Invoke<T0, T1, TRes>(IsolatedObject? instance, T0 param0, T1 param1)
     {
         Span<int> argAddresses = stackalloc int[2];
         using var allocator = _runtimeInstance.GetAllocator();
-        argAddresses[0] = Serialize(param0, allocator);
-        argAddresses[1] = Serialize(param1, allocator);
-
-        try
-        {
-            return _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, argAddresses);
-        }
-        finally
-        {
-            _runtimeInstance.Free(argAddresses[0]);
-            _runtimeInstance.Free(argAddresses[1]);
-        }
+        return Invoke<T0, T1, TRes>(instance, param0, param1, argAddresses, allocator);
     }
 
     public TRes Invoke<T0, T1, T2, TRes>(IsolatedObject? instance, T0 param0, T1 param1, T2 param2)
     {
         Span<int> argAddresses = stackalloc int[3];
         using var allocator = _runtimeInstance.GetAllocator();
-        argAddresses[0] = Serialize(param0, allocator);
-        argAddresses[1] = Serialize(param1, allocator);
-        argAddresses[2] = Serialize(param2, allocator);
-
-        try
-        {
-            return _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, argAddresses);
-        }
-        finally
-        {
-            _runtimeInstance.Free(argAddresses[0]);
-            _runtimeInstance.Free(argAddresses[1]);
-            _runtimeInstance.Free(argAddresses[2]);
-        }
+        return Invoke<T0, T1, T2, TRes>(instance, param0, param1, param2, argAddresses, allocator);
     }
 
     public TRes Invoke<T0, T1, T2, T3, TRes>(IsolatedObject? instance, T0 param0, T1 param1, T2 param2, T3 param3)
     {
         Span<int> argAddresses = stackalloc int[4];
         using var allocator = _runtimeInstance.GetAllocator();
-        argAddresses[0] = Serialize(param0, allocator);
-        argAddresses[1] = Serialize(param1, allocator);
-        argAddresses[2] = Serialize(param2, allocator);
-        argAddresses[3] = Serialize(param3, allocator);
-
-        try
-        {
-            return _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, argAddresses);
-        }
-        finally
-        {
-            _runtimeInstance.Free(argAddresses[0]);
-            _runtimeInstance.Free(argAddresses[1]);
-            _runtimeInstance.Free(argAddresses[2]);
-            _runtimeInstance.Free(argAddresses[3]);
-        }
+        return Invoke<T0, T1, T2, T3, TRes>(instance, param0, param1, param2, param3, argAddresses, allocator);
     }
 
     public TRes Invoke<T0, T1, T2, T3, T4, TRes>(IsolatedObject? instance, T0 param0, T1 param1, T2 param2, T3 param3, T4 param4)
     {
         Span<int> argAddresses = stackalloc int[5];
         using var allocator = _runtimeInstance.GetAllocator();
-        argAddresses[0] = Serialize(param0, allocator);
-        argAddresses[1] = Serialize(param1, allocator);
-        argAddresses[2] = Serialize(param2, allocator);
-        argAddresses[3] = Serialize(param3, allocator);
-        argAddresses[4] = Serialize(param4, allocator);
-
-        try
-        {
-            return _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, argAddresses);
-        }
-        finally
-        {
-            _runtimeInstance.Free(argAddresses[0]);
-            _runtimeInstance.Free(argAddresses[1]);
-            _runtimeInstance.Free(argAddresses[2]);
-            _runtimeInstance.Free(argAddresses[3]);
-            _runtimeInstance.Free(argAddresses[4]);
-        }
+        return Invoke<T0, T1, T2, T3, T4, TRes>(instance, param0, param1, param2, param3, param4, argAddresses, allocator);
     }
 
     public TRes Invoke<TRes>(IsolatedObject? instance, params object[] args)
@@ -151,19 +163,20 @@ public class IsolatedMethod : IEquatable<IsolatedMethod>
     {
         Span<int> argAddresses = stackalloc int[args.Length];
         using var allocator = _runtimeInstance.GetAllocator();
-        for (int i = 0; i < args.Length; i++)
-        {
-            argAddresses[i] = Serialize(args[i], allocator);
-        }
+        int i = 0;
         try
         {
+            for (; i < args.Length; i++)
+            {
+                argAddresses[i] = Serialize(args[i], allocator);
+            }
             return _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, argAddresses);
         }
         finally
         {
-            for (int i = 0; i < args.Length; i++)
+            for (int j = 0; j < i; j++)
             {
-                _runtimeInstance.Free(argAddresses[i]);
+                _runtimeInstance.Free(argAddresses[j]);
             }
         }
     }

--- a/src/DotNetIsolator/IsolatedMethod.cs
+++ b/src/DotNetIsolator/IsolatedMethod.cs
@@ -1,9 +1,8 @@
 ﻿using MessagePack;
-using System.Buffers;
 
 namespace DotNetIsolator;
 
-public class IsolatedMethod : IEquatable<IsolatedMethod>
+public class IsolatedMethod : IsolatedMember, IEquatable<IsolatedMethod>
 {
     private readonly IsolatedRuntime _runtimeInstance;
     private readonly int _monoMethodPtr;
@@ -47,6 +46,12 @@ public class IsolatedMethod : IEquatable<IsolatedMethod>
         return allocator.Release();
     }
 
+    protected override IsolatedObject GetReflectionObject()
+    {
+        return _runtimeInstance.GetReflectionMethod(_monoMethodPtr);
+    }
+
+    #region Invoke overloads
     private TRes Invoke<TRes>(IsolatedObject? instance, Span<int> argAddresses)
     {
         return _runtimeInstance.InvokeMethod<TRes>(_monoMethodPtr, instance, argAddresses);
@@ -206,4 +211,5 @@ public class IsolatedMethod : IEquatable<IsolatedMethod>
 
     public void InvokeVoid<T0, T1, T2, T3, T4>(IsolatedObject? instance, T0 param0, T1 param1, T2 param2, T3 param3, T4 param4)
         => Invoke<T0, T1, T2, T3, T4, object>(instance, param0, param1, param2, param3, param4);
+    #endregion
 }

--- a/src/DotNetIsolator/IsolatedObject.cs
+++ b/src/DotNetIsolator/IsolatedObject.cs
@@ -18,6 +18,11 @@ public class IsolatedObject : IDisposable, IIsolatedGCHandle, IEquatable<Isolate
 
     internal int GuestGCHandle { get; private set; }
 
+    public static explicit operator IsolatedMember(IsolatedObject obj)
+    {
+        return obj._runtimeInstance.GetReflectedMember(obj.GuestGCHandle);
+    }
+
     public override string ToString()
     {
         return _runtimeInstance.ToStringMethod.Invoke<string>(this);

--- a/src/DotNetIsolator/IsolatedObject.cs
+++ b/src/DotNetIsolator/IsolatedObject.cs
@@ -1,6 +1,6 @@
 ﻿namespace DotNetIsolator;
 
-public class IsolatedObject : IDisposable
+public class IsolatedObject : IDisposable, IIsolatedGCHandle
 {
     private readonly IsolatedRuntime _runtimeInstance;
     private readonly int _monoClassPtr;
@@ -21,6 +21,11 @@ public class IsolatedObject : IDisposable
     public override string ToString()
     {
         return _runtimeInstance.ToStringMethod.Invoke<string>(this);
+    }
+
+    public int? GetGCHandle(IsolatedRuntime runtime)
+    {
+        return runtime == _runtimeInstance ? GuestGCHandle : null;
     }
 
     private IsolatedMethod FindMethod(string methodName, int numArgs = -1)

--- a/src/DotNetIsolator/IsolatedObject.cs
+++ b/src/DotNetIsolator/IsolatedObject.cs
@@ -66,6 +66,11 @@ public class IsolatedObject : IDisposable
     public void InvokeVoid<T0, T1, T2, T3, T4>(string methodName, T0 param0, T1 param1, T2 param2, T3 param3, T4 param4)
         => FindMethod(methodName, 5).InvokeVoid(this, param0, param1, param2, param3, param4);
 
+    public T Deserialize<T>()
+    {
+        return _runtimeInstance.InvokeDotNetMethod<T>(0, this, default);
+    }
+
     protected virtual void Dispose(bool disposing)
     {
         if (GuestGCHandle != 0)

--- a/src/DotNetIsolator/IsolatedObject.cs
+++ b/src/DotNetIsolator/IsolatedObject.cs
@@ -93,6 +93,14 @@ public class IsolatedObject : IDisposable, IIsolatedGCHandle
             _runtimeInstance.ReleaseGCHandle(GuestGCHandle);
             GuestGCHandle = 0;
         }
+        if (disposing)
+        {
+            if (_classCached != null)
+            {
+                _classCached.Dispose();
+                _classCached = null;
+            }
+        }
     }
 
     public void Dispose()

--- a/src/DotNetIsolator/IsolatedObject.cs
+++ b/src/DotNetIsolator/IsolatedObject.cs
@@ -1,6 +1,6 @@
 ﻿namespace DotNetIsolator;
 
-public class IsolatedObject
+public class IsolatedObject : IDisposable
 {
     private readonly IsolatedRuntime _runtimeInstance;
     private readonly string _assemblyName;
@@ -66,7 +66,7 @@ public class IsolatedObject
     public void InvokeVoid<T0, T1, T2, T3, T4>(string methodName, T0 param0, T1 param1, T2 param2, T3 param3, T4 param4)
         => FindMethod(methodName, 5).InvokeVoid(this, param0, param1, param2, param3, param4);
 
-    public void ReleaseGCHandle()
+    protected virtual void Dispose(bool disposing)
     {
         if (GuestGCHandle != 0)
         {
@@ -75,8 +75,14 @@ public class IsolatedObject
         }
     }
 
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
     ~IsolatedObject()
     {
-        ReleaseGCHandle();
+        Dispose(false);
     }
 }

--- a/src/DotNetIsolator/IsolatedObject.cs
+++ b/src/DotNetIsolator/IsolatedObject.cs
@@ -18,6 +18,11 @@ public class IsolatedObject : IDisposable
 
     internal int GuestGCHandle { get; private set; }
 
+    public override string ToString()
+    {
+        return _runtimeInstance.ToStringMethod.Invoke<string>(this);
+    }
+
     private IsolatedMethod FindMethod(string methodName, int numArgs = -1)
     {
         if (GuestGCHandle == 0)

--- a/src/DotNetIsolator/IsolatedObject.cs
+++ b/src/DotNetIsolator/IsolatedObject.cs
@@ -3,13 +3,13 @@
 public class IsolatedObject : IDisposable
 {
     private readonly IsolatedRuntime _runtimeInstance;
-    private readonly int _monoClass;
+    private readonly int _monoClassPtr;
 
-    internal IsolatedObject(IsolatedRuntime runtimeInstance, int gcHandle, int monoClass)
+    internal IsolatedObject(IsolatedRuntime runtimeInstance, int gcHandle, int monoClassPtr)
     {
         _runtimeInstance = runtimeInstance;
         GuestGCHandle = gcHandle;
-        _monoClass = monoClass;
+        _monoClassPtr = monoClassPtr;
     }
 
     internal int GuestGCHandle { get; private set; }
@@ -21,7 +21,7 @@ public class IsolatedObject : IDisposable
             throw new InvalidOperationException("Cannot look up instance method because the object has already been released.");
         }
 
-        return _runtimeInstance.GetMethod(_monoClass, methodName);
+        return _runtimeInstance.GetMethod(_monoClassPtr, methodName, numArgs);
     }
 
     public TRes Invoke<TRes>(string methodName)
@@ -68,7 +68,7 @@ public class IsolatedObject : IDisposable
 
     public T Deserialize<T>()
     {
-        return _runtimeInstance.InvokeDotNetMethod<T>(0, this, default);
+        return _runtimeInstance.InvokeMethod<T>(0, this, default);
     }
 
     protected virtual void Dispose(bool disposing)

--- a/src/DotNetIsolator/IsolatedRuntime.cs
+++ b/src/DotNetIsolator/IsolatedRuntime.cs
@@ -306,30 +306,16 @@ public class IsolatedRuntime : IDisposable
     {
         // TODO: Find a way of not serializing value.Target if it doesn't contain any fields we care about serializing
         // This makes invoking static lambdas vastly faster. It's not clear to me why the target is nonnull in these cases anyway.
-        var targetInGuest = value.Target is null ? null : CopyObject(value.Target);
-        try
-        {
-            LookupDelegateMethod(value).InvokeVoid(targetInGuest);
-        }
-        finally
-        {
-            targetInGuest?.ReleaseGCHandle(); // TODO: Make this into a 'Dispose' call on IsolatedObject?
-        }
+        using var targetInGuest = value.Target is null ? null : CopyObject(value.Target);
+        LookupDelegateMethod(value).InvokeVoid(targetInGuest);
     }
 
     public TRes Invoke<TRes>(Func<TRes> value)
     {
         // TODO: Find a way of not serializing value.Target if it doesn't contain any fields we care about serializing
         // This makes invoking static lambdas vastly faster. It's not clear to me why the target is nonnull in these cases anyway.
-        var targetInGuest = value.Target is null ? null : CopyObject(value.Target);
-        try
-        {
-            return LookupDelegateMethod(value).Invoke<TRes>(targetInGuest);
-        }
-        finally
-        {
-            targetInGuest?.ReleaseGCHandle(); // TODO: Make this into a 'Dispose' call on IsolatedObject?
-        }
+        using var targetInGuest = value.Target is null ? null : CopyObject(value.Target);
+        return LookupDelegateMethod(value).Invoke<TRes>(targetInGuest);
     }
 
     public void RegisterCallback(string name, Delegate callback)

--- a/src/DotNetIsolator/IsolatedRuntime.cs
+++ b/src/DotNetIsolator/IsolatedRuntime.cs
@@ -522,12 +522,10 @@ public class IsolatedRuntime : MemoryManager<byte>, IDisposable
     public void RegisterCallback(string name, Delegate callback)
         => _registeredCallbacks.Add(name, callback);
 
-    private IsolatedMethod LookupDelegateMethod(MulticastDelegate @delegate)
+    private IsolatedMethod LookupDelegateMethod(Delegate @delegate)
     {
-        var method = @delegate.Method;
-        var methodType = method.DeclaringType!;
-        var wasmMethod = this.GetMethod(methodType, method.Name, -1);
-        return wasmMethod;
+        return this.GetMethod(@delegate.Method)
+            ?? throw new ArgumentException($"Cannot find closure method {@delegate.Method.Name}.");
     }
 
     internal int AcceptCallFromGuest(int invocationPtr, int invocationLength, int resultPtrPtr, int resultLengthPtr)

--- a/src/DotNetIsolator/IsolatedRuntime.cs
+++ b/src/DotNetIsolator/IsolatedRuntime.cs
@@ -104,7 +104,7 @@ public class IsolatedRuntime : IDisposable
 
                 if (monoClassPtr == 0)
                 {
-                    throw new IsolatedException(null);
+                    throw new IsolatedException();
                 }
 
                 return new IsolatedClass(this, monoClassPtr);
@@ -134,7 +134,7 @@ public class IsolatedRuntime : IDisposable
             if (errorMessageBuf.Value != 0)
             {
                 var errorMessage = ReadDotNetString(errorMessageBuf.Value);
-                throw new IsolatedException(errorMessage);
+                throw new IsolatedException(errorMessage, new IsolatedObject(this, gcHandle, _getDotNetClass(gcHandle)));
             }
 
             return new IsolatedObject(this, gcHandle, _getDotNetClass(gcHandle));
@@ -204,7 +204,7 @@ public class IsolatedRuntime : IDisposable
 
                 if (methodPtr == 0)
                 {
-                    throw new IsolatedException(null);
+                    throw new IsolatedException();
                 }
 
                 return new IsolatedMethod(this, methodPtr);
@@ -241,7 +241,7 @@ public class IsolatedRuntime : IDisposable
             if (invocation.ResultException != 0)
             {
                 var exceptionString = ReadDotNetString(invocation.ResultException);
-                throw new IsolatedException(exceptionString);
+                throw new IsolatedException(exceptionString, new IsolatedObject(this, invocation.ResultGCHandle, invocation.ResultPtr));
             }
 
             if (invocation.ResultPtr == 0)
@@ -252,8 +252,7 @@ public class IsolatedRuntime : IDisposable
             {
                 if (asHandle)
                 {
-                    var resulTypePtr = invocation.ResultPtr;
-                    return (TRes)(object)new IsolatedObject(this, invocation.ResultGCHandle, resulTypePtr);
+                    return (TRes)(object)new IsolatedObject(this, invocation.ResultGCHandle, invocation.ResultPtr);
                 }
                 else
                 {

--- a/src/DotNetIsolator/IsolatedRuntime.cs
+++ b/src/DotNetIsolator/IsolatedRuntime.cs
@@ -2,6 +2,7 @@
 using MessagePack;
 using MessagePack.Resolvers;
 using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Text;
 using Wasmtime;
@@ -219,12 +220,12 @@ public class IsolatedRuntime : IDisposable
     internal TRes InvokeDotNetMethod<TRes>(int monoMethodPtr, IsolatedObject? instance, ReadOnlySpan<int> argAddresses)
     {
         // Prepare an Invocation struct within guest memory
-        var len = Marshal.SizeOf<Invocation>();
+        var len = Unsafe.SizeOf<Invocation>();
         var wasmPtr = _malloc(len); // Freed below
         try
         {
             var invocationStruct = _memory.GetSpan(wasmPtr, len);
-            ref var invocation = ref MemoryMarshal.AsRef<Invocation>(invocationStruct);
+            ref var invocation = ref MemoryMarshal.Cast<byte, Invocation>(invocationStruct)[0];
             invocation = new()
             {
                 TargetGCHandle = instance is IsolatedObject o ? o.GuestGCHandle : 0,

--- a/src/DotNetIsolator/IsolatedRuntime.cs
+++ b/src/DotNetIsolator/IsolatedRuntime.cs
@@ -93,7 +93,7 @@ public class IsolatedRuntime : IDisposable
                     CopyValue(info.Namespace),
                     CopyValue(monoClassName));
 
-                if(monoClassPtr == 0)
+                if (monoClassPtr == 0)
                 {
                     throw new IsolatedException(null);
                 }
@@ -189,11 +189,11 @@ public class IsolatedRuntime : IDisposable
             {
                 // All these CopyValue strings are freed inside the C code
                 var methodPtr = _lookupDotNetMethod(
-                    monoClassPtr,
+                    info.MonoClass,
                     CopyValue(info.MethodName),
                     info.NumArgs);
 
-                if(methodPtr != 0)
+                if (methodPtr == 0)
                 {
                     throw new IsolatedException(null);
                 }

--- a/src/DotNetIsolator/IsolatedRuntime.cs
+++ b/src/DotNetIsolator/IsolatedRuntime.cs
@@ -152,11 +152,7 @@ public class IsolatedRuntime : IDisposable
         }
 
         var valueUtf8Length = Encoding.UTF8.GetByteCount(value);
-        var resultPtr = _malloc(valueUtf8Length + 1);
-        if (resultPtr == 0)
-        {
-            throw new InvalidOperationException($"malloc failed when trying to allocate {valueUtf8Length} bytes");
-        }
+        var resultPtr = Alloc(valueUtf8Length + 1);
 
         var destinationSpan = _memory.GetSpan(resultPtr, valueUtf8Length);
         Encoding.UTF8.GetBytes(value, destinationSpan);
@@ -169,11 +165,7 @@ public class IsolatedRuntime : IDisposable
         var lengthPrefixSize = addLengthPrefix ? 4 : 0;
         var valueAsBytes = MemoryMarshal.AsBytes(value);
         var length = valueAsBytes.Length;
-        var resultPtr = _malloc(length + lengthPrefixSize);
-        if (resultPtr == 0)
-        {
-            throw new InvalidOperationException($"malloc failed when trying to allocate {length + 4} bytes");
-        }
+        var resultPtr = Alloc(length + lengthPrefixSize);
 
         if (addLengthPrefix)
         {
@@ -325,7 +317,7 @@ public class IsolatedRuntime : IDisposable
         var ptr = _malloc(size);
         if (ptr == 0)
         {
-            throw new OutOfMemoryException("Not enough memory for malloc.");
+            throw new OutOfMemoryException($"malloc failed when trying to allocate {size} bytes");
         }
         return ptr;
     }
@@ -335,7 +327,7 @@ public class IsolatedRuntime : IDisposable
         var ptr = _realloc(malloced_ptr, new_size);
         if(ptr == 0)
         {
-            throw new OutOfMemoryException("Not enough memory for realloc.");
+            throw new OutOfMemoryException($"realloc failed when trying to allocate {new_size} bytes");
         }
         return ptr;
     }

--- a/src/DotNetIsolator/IsolatedRuntime.cs
+++ b/src/DotNetIsolator/IsolatedRuntime.cs
@@ -192,8 +192,17 @@ public class IsolatedRuntime : IDisposable
     internal IsolatedAllocator GetLengthPrefixedAllocator()
     {
         var allocator = GetAllocator();
-        allocator.Advance(4);
+        InitLengthPrefixedAllocator(allocator);
         return allocator;
+    }
+
+    internal void InitLengthPrefixedAllocator(IsolatedAllocator allocator)
+    {
+        if (allocator.WrittenBytes != 0)
+        {
+            throw new ArgumentException("The allocator must be positioned at 0.", nameof(allocator));
+        }
+        allocator.Advance(4);
     }
 
     internal int ReleaseLengthPrefixedAllocator(IsolatedAllocator allocator)

--- a/src/DotNetIsolator/IsolatedRuntime.cs
+++ b/src/DotNetIsolator/IsolatedRuntime.cs
@@ -36,6 +36,9 @@ public class IsolatedRuntime : IDisposable
     private readonly Dictionary<string, Delegate> _registeredCallbacks = new();
     private bool _isDisposed;
 
+    public IsolatedClass ObjectClass { get; }
+    public IsolatedMethod ToStringMethod { get; }
+
     public IsolatedRuntime(IsolatedRuntimeHost host)
     {
         var store = new Store(host.Engine);
@@ -69,6 +72,12 @@ public class IsolatedRuntime : IDisposable
         // _start is already called in preinitialization, so we can skip it now
         // var startExport = _instance.GetAction("_start") ?? throw new InvalidOperationException("Couldn't find export '_start'");
         // startExport.Invoke();
+
+        ObjectClass = this.GetClass<object>()
+            ?? throw new InvalidOperationException("System.Object could not be found");
+
+        ToStringMethod = ObjectClass.GetMethod(nameof(Object.ToString), 0)
+            ?? throw new InvalidOperationException("System.Object.ToString could not be found");
     }
 
     internal static IsolatedRuntime FromStore(Store store)

--- a/src/DotNetIsolator/IsolatedRuntime.cs
+++ b/src/DotNetIsolator/IsolatedRuntime.cs
@@ -230,7 +230,7 @@ public class IsolatedRuntime : IDisposable
                     throw new IsolatedException(errorString);
                 }
 
-                return new IsolatedMethod(this, info.MethodName, methodPtr);
+                return new IsolatedMethod(this, methodPtr);
             }
             finally
             {

--- a/src/DotNetIsolator/IsolatedRuntime.cs
+++ b/src/DotNetIsolator/IsolatedRuntime.cs
@@ -339,7 +339,7 @@ public class IsolatedRuntime : IDisposable
             if (invocation.ResultException != 0)
             {
                 var exceptionString = ReadDotNetString(invocation.ResultException);
-                throw new IsolatedException(exceptionString, new IsolatedObject(this, invocation.ResultGCHandle, invocation.ResultPtr));
+                throw new IsolatedException(exceptionString == "" ? null : exceptionString, new IsolatedObject(this, invocation.ResultGCHandle, invocation.ResultPtr));
             }
 
             if (invocation.ResultPtr == 0)

--- a/src/DotNetIsolator/IsolatedRuntime.cs
+++ b/src/DotNetIsolator/IsolatedRuntime.cs
@@ -218,8 +218,8 @@ public class IsolatedRuntime : IDisposable
         });
     }
 
-    // Internal because you only need to call it via DotNetMethod
-    internal TRes InvokeDotNetMethod<TRes>(int monoMethodPtr, IsolatedObject? instance, ReadOnlySpan<int> argAddresses)
+    // Internal because you only need to call it via IsolatedMethod
+    internal TRes InvokeMethod<TRes>(int monoMethodPtr, IsolatedObject? instance, ReadOnlySpan<int> argAddresses)
     {
         // Prepare an Invocation struct within guest memory
         var len = Unsafe.SizeOf<Invocation>();

--- a/src/DotNetIsolator/IsolatedRuntime.cs
+++ b/src/DotNetIsolator/IsolatedRuntime.cs
@@ -410,7 +410,7 @@ public class IsolatedRuntime : IDisposable
             case MemberTypes.Constructor:
                 return new IsolatedMethod(this, resultMemberPtr.Value);
             default:
-                throw new NotSupportedException();
+                throw new ArgumentException("Handle does not point to a valid reflection object.", nameof(gcHandle));
         }
     }
 

--- a/src/DotNetIsolator/IsolatedRuntimeExtensions.cs
+++ b/src/DotNetIsolator/IsolatedRuntimeExtensions.cs
@@ -2,48 +2,48 @@
 
 public static class IsolatedRuntimeExtensions
 {
-    public static IsolatedClass GetClass(this IsolatedRuntime runtime, Type type)
+    public static IsolatedClass? GetClass(this IsolatedRuntime runtime, Type type)
     {
         return runtime.GetClass(type.Assembly.GetName().Name!, type.Namespace, type.DeclaringType?.Name, type.Name);
     }
 
-    public static IsolatedClass GetClass<T>(this IsolatedRuntime runtime)
+    public static IsolatedClass? GetClass<T>(this IsolatedRuntime runtime)
     {
         return runtime.GetClass(typeof(T));
     }
 
-    public static IsolatedMethod GetMethod(this IsolatedRuntime runtime, Type type, string methodName)
+    public static IsolatedMethod? GetMethod(this IsolatedRuntime runtime, Type type, string methodName)
     {
-        return runtime.GetClass(type).GetMethod(methodName);
+        return runtime.GetClass(type)?.GetMethod(methodName);
     }
 
-    public static IsolatedMethod GetMethod(this IsolatedRuntime runtime, Type type, string methodName, int numArgs)
+    public static IsolatedMethod? GetMethod(this IsolatedRuntime runtime, Type type, string methodName, int numArgs)
     {
-        return runtime.GetClass(type).GetMethod(methodName, numArgs);
+        return runtime.GetClass(type)?.GetMethod(methodName, numArgs);
     }
 
-    public static IsolatedMethod GetMethod(this IsolatedRuntime runtime, string assemblyName, string? @namespace, string? declaringTypeName, string typeName, string methodName, int numArgs = -1)
+    public static IsolatedMethod? GetMethod(this IsolatedRuntime runtime, string assemblyName, string? @namespace, string? declaringTypeName, string typeName, string methodName, int numArgs = -1)
     {
-        return runtime.GetClass(assemblyName, @namespace, declaringTypeName, typeName).GetMethod(methodName, numArgs);
+        return runtime.GetClass(assemblyName, @namespace, declaringTypeName, typeName)?.GetMethod(methodName, numArgs);
     }
 
-    public static IsolatedObject CreateObject(this IsolatedRuntime runtime, string assemblyName, string? @namespace, string className)
+    public static IsolatedObject? CreateObject(this IsolatedRuntime runtime, string assemblyName, string? @namespace, string className)
     {
-        return runtime.GetClass(assemblyName, @namespace, declaringTypeName: null, className).CreateInstance();
+        return runtime.GetClass(assemblyName, @namespace, declaringTypeName: null, className)?.CreateInstance();
     }
 
-    public static IsolatedObject CreateObject(this IsolatedRuntime runtime, string assemblyName, string? @namespace, string? declaringTypeName, string className)
+    public static IsolatedObject? CreateObject(this IsolatedRuntime runtime, string assemblyName, string? @namespace, string? declaringTypeName, string className)
     {
-        return runtime.GetClass(assemblyName, @namespace, declaringTypeName, className).CreateInstance();
+        return runtime.GetClass(assemblyName, @namespace, declaringTypeName, className)?.CreateInstance();
     }
 
-    public static IsolatedObject CreateObject(this IsolatedRuntime runtime, Type type)
+    public static IsolatedObject? CreateObject(this IsolatedRuntime runtime, Type type)
     {
-        return runtime.GetClass(type).CreateInstance();
+        return runtime.GetClass(type)?.CreateInstance();
     }
 
-    public static IsolatedObject CreateObject<T>(this IsolatedRuntime runtime)
+    public static IsolatedObject? CreateObject<T>(this IsolatedRuntime runtime)
     {
-        return runtime.GetClass<T>().CreateInstance();
+        return runtime.GetClass(typeof(T))?.CreateInstance();
     }
 }

--- a/src/DotNetIsolator/IsolatedRuntimeExtensions.cs
+++ b/src/DotNetIsolator/IsolatedRuntimeExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace DotNetIsolator;
+﻿using System.Reflection;
+
+namespace DotNetIsolator;
 
 public static class IsolatedRuntimeExtensions
 {
@@ -10,6 +12,11 @@ public static class IsolatedRuntimeExtensions
     public static IsolatedClass? GetClass<T>(this IsolatedRuntime runtime)
     {
         return runtime.GetClass(typeof(T));
+    }
+
+    public static IsolatedMethod? GetMethod(this IsolatedRuntime runtime, MethodInfo method)
+    {
+        return runtime.GetClass(method.DeclaringType)?.GetMethod(method.Name, method.GetParameters().Length);
     }
 
     public static IsolatedMethod? GetMethod(this IsolatedRuntime runtime, Type type, string methodName)

--- a/src/DotNetIsolator/IsolatedRuntimeExtensions.cs
+++ b/src/DotNetIsolator/IsolatedRuntimeExtensions.cs
@@ -1,0 +1,49 @@
+﻿namespace DotNetIsolator;
+
+public static class IsolatedRuntimeExtensions
+{
+    public static IsolatedClass GetClass(this IsolatedRuntime runtime, Type type)
+    {
+        return runtime.GetClass(type.Assembly.GetName().Name!, type.Namespace, type.DeclaringType?.Name, type.Name);
+    }
+
+    public static IsolatedClass GetClass<T>(this IsolatedRuntime runtime)
+    {
+        return runtime.GetClass(typeof(T));
+    }
+
+    public static IsolatedMethod GetMethod(this IsolatedRuntime runtime, Type type, string methodName)
+    {
+        return runtime.GetClass(type).GetMethod(methodName);
+    }
+
+    public static IsolatedMethod GetMethod(this IsolatedRuntime runtime, Type type, string methodName, int numArgs)
+    {
+        return runtime.GetClass(type).GetMethod(methodName, numArgs);
+    }
+
+    public static IsolatedMethod GetMethod(this IsolatedRuntime runtime, string assemblyName, string? @namespace, string? declaringTypeName, string typeName, string methodName, int numArgs = -1)
+    {
+        return runtime.GetClass(assemblyName, @namespace, declaringTypeName, typeName).GetMethod(methodName, numArgs);
+    }
+
+    public static IsolatedObject CreateObject(this IsolatedRuntime runtime, string assemblyName, string? @namespace, string className)
+    {
+        return runtime.GetClass(assemblyName, @namespace, declaringTypeName: null, className).CreateInstance();
+    }
+
+    public static IsolatedObject CreateObject(this IsolatedRuntime runtime, string assemblyName, string? @namespace, string? declaringTypeName, string className)
+    {
+        return runtime.GetClass(assemblyName, @namespace, declaringTypeName, className).CreateInstance();
+    }
+
+    public static IsolatedObject CreateObject(this IsolatedRuntime runtime, Type type)
+    {
+        return runtime.GetClass(type).CreateInstance();
+    }
+
+    public static IsolatedObject CreateObject<T>(this IsolatedRuntime runtime)
+    {
+        return runtime.GetClass<T>().CreateInstance();
+    }
+}

--- a/src/DotNetIsolator/IsolatedRuntimeExtensions.cs
+++ b/src/DotNetIsolator/IsolatedRuntimeExtensions.cs
@@ -6,6 +6,11 @@ public static class IsolatedRuntimeExtensions
 {
     public static IsolatedClass? GetClass(this IsolatedRuntime runtime, Type type)
     {
+        if(type.IsGenericType && !type.IsGenericTypeDefinition)
+        {
+            var typeArgs = type.GetGenericArguments().Select(arg => runtime.GetClass(arg)).ToArray();
+            return runtime.GetClass(type.GetGenericTypeDefinition())?.MakeGenericClass(typeArgs!);
+        }
         return runtime.GetClass(type.Assembly.GetName().Name!, type.Namespace, type.DeclaringType?.Name, type.Name);
     }
 
@@ -16,6 +21,11 @@ public static class IsolatedRuntimeExtensions
 
     public static IsolatedMethod? GetMethod(this IsolatedRuntime runtime, MethodInfo method)
     {
+        if(method.IsGenericMethod && !method.IsGenericMethodDefinition)
+        {
+            var typeArgs = method.GetGenericArguments().Select(arg => runtime.GetClass(arg)).ToArray();
+            return runtime.GetMethod(method.GetGenericMethodDefinition())?.MakeGenericMethod(typeArgs!);
+        }
         return runtime.GetClass(method.DeclaringType)?.GetMethod(method.Name, method.GetParameters().Length);
     }
 

--- a/src/DotNetIsolator/IsolatedRuntimeHost.cs
+++ b/src/DotNetIsolator/IsolatedRuntimeHost.cs
@@ -45,7 +45,7 @@ public class IsolatedRuntimeHost : IDisposable
 
         if (_wasiConfiguration is not null)
         {
-            throw new InvalidOperationException($"{WithWasiConfiguration} can only be called once.");
+            throw new InvalidOperationException($"{nameof(WithWasiConfiguration)} can only be called once.");
         }
 
         _wasiConfiguration = configuration;

--- a/src/DotNetIsolator/ShadowStack.cs
+++ b/src/DotNetIsolator/ShadowStack.cs
@@ -35,9 +35,9 @@ internal class ShadowStack : IDisposable
         _stackPtr += len;
 
         var valueBytes = _memory.GetSpan(ptr, len);
-        ref var value = ref MemoryMarshal.AsRef<T>(valueBytes);
+        var value = MemoryMarshal.Cast<byte, T>(valueBytes);
 
-        return new ShadowStackEntry<T>(this, ref value, ptr);
+        return new ShadowStackEntry<T>(this, value, ptr);
     }
 
     public void Pop<T>(int expectedAddress) where T : unmanaged

--- a/src/DotNetIsolator/ShadowStackEntry.cs
+++ b/src/DotNetIsolator/ShadowStackEntry.cs
@@ -14,7 +14,7 @@ internal readonly ref struct ShadowStackEntry<T> where T: unmanaged
         Address = address;
     }
 
-    public void Pop()
+    public void Dispose()
     {
         _owner.Pop<T>(Address);
     }

--- a/src/DotNetIsolator/ShadowStackEntry.cs
+++ b/src/DotNetIsolator/ShadowStackEntry.cs
@@ -2,14 +2,15 @@
 
 internal readonly ref struct ShadowStackEntry<T> where T: unmanaged
 {
-    public readonly ref T Value;
+    private readonly Span<T> _value;
+    public ref T Value => ref _value[0];
     public readonly int Address;
     private readonly ShadowStack _owner;
 
-    public ShadowStackEntry(ShadowStack owner, ref T value, int address)
+    public ShadowStackEntry(ShadowStack owner, Span<T> value, int address)
     {
         _owner = owner;
-        Value = ref value;
+        _value = value;
         Address = address;
     }
 

--- a/test/DotNetIsolator.Test/HostCallbackTest.cs
+++ b/test/DotNetIsolator.Test/HostCallbackTest.cs
@@ -116,7 +116,7 @@ public class HostCallbackTest : IDisposable
 
     public void Dispose()
     {
-        _runtime.Dispose();
+        ((IDisposable)_runtime).Dispose();
     }
 
     class Person

--- a/test/DotNetIsolator.Test/LambdaInvocationTest.cs
+++ b/test/DotNetIsolator.Test/LambdaInvocationTest.cs
@@ -46,7 +46,7 @@ public class LambdaInvocationTest : IDisposable
 
     public void Dispose()
     {
-        _runtime.Dispose();
+        ((IDisposable)_runtime).Dispose();
     }
 
     private class Person

--- a/test/DotNetIsolator.Test/MethodInvocationTest.cs
+++ b/test/DotNetIsolator.Test/MethodInvocationTest.cs
@@ -114,7 +114,7 @@ public class MethodInvocationTest : IDisposable
 
     public void Dispose()
     {
-        _runtime.Dispose();
+        ((IDisposable)_runtime).Dispose();
     }
 
     class TestClass

--- a/test/DotNetIsolator.Test/StartupTest.cs
+++ b/test/DotNetIsolator.Test/StartupTest.cs
@@ -21,7 +21,7 @@ public class StartupTest
         var p = runtime.CreateObject<object>();
 
         // Can find a method on it
-        var toString = p.FindMethod(nameof(object.ToString));
+        var toString = p.Class.GetMethod(nameof(object.ToString));
         Assert.NotNull(toString);
 
         // Can invoke a method on it


### PR DESCRIPTION
I've tried to update this project a bit to make it more convenient to build APIs for. There were several changes, fixes etc.

* The project has been ported to .NET Standard 2.0. The isolated runtime remains at .NET 6, meaning it can be invoked freely from lower versions of .NET Core, and from .NET Framework.
* `IsolatedObject` and other remote objects implement `IDisposable`, `IEquatable`, and similar, controlling the existence of their remote counterpart in memory (only the handles are disposed/compared ‒ if the remote object implements `IDisposable` or `IEquatable` itself, it is not called). `ToString` is implemented as well, but is actually routed to the remote object's `ToString` implementation.
* * Added `IsolatedClass` and abstract `IsolatedMember` for better reflection. `IsolatedObject` can be cast back and forth between `IsolatedMember` for runtime members inheriting from `MemberInfo`.
* `IsolatedMethod` can be invoked with an arbitrary number of arguments. Exceptions from within the call are serialized back to the host (I am however unsure if messagepack's deserialization of `Exception` could be potentially dangerous).
* `IsolatedMethod` can be invoked with an `IsolatedObject` argument, or any remote object (such as `IsolatedMethod` being represented as `MethodInfo` in the guest).
* `IsolatedMethod` can be abstract or virtual, resolving to the proper concrete method when invoked on an `IsolatedObject`.
* `IsolatedMethod` can be looked up using its full signature (as offered by Mono).
* `IsolatedMethod` supports generic instantiation.
* Class or method lookup returns `null` instead of an exception if not found.
* Serialization of arguments is handled through a new implementation of `IBufferWriter` ‒ `IsolatedAllocator`, which handles reallocations of guest memory and automatically does length-prefixing.
* Fixed valuetype handling related to unboxing.